### PR TITLE
Convert usize to u32 for count()

### DIFF
--- a/src/actor.rs
+++ b/src/actor.rs
@@ -122,7 +122,7 @@ impl ActorContainer {
         self.pool.free(actor_handle);
     }
 
-    pub fn count(&self) -> usize {
+    pub fn count(&self) -> u32 {
         self.pool.alive_count()
     }
 


### PR DESCRIPTION
This fixes Iapetus after my changes to Pool in [rg3d](https://github.com/rg3dengine/rg3d/pull/247) (there are other things broken by your changes though so it won't compile)