### PR TITLE
correct the path to the fyrox crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 opt-level = 3
 
 [dependencies]
-fyrox = { path = "../fyrox" }
+fyrox = { path = "../rg3d" }
 ron = "0.7.0"
 serde = "^1.0.0"
 


### PR DESCRIPTION
When following the ``How to build`` Guide in the README the name of the fyrox dependency is not correct in the Cargo.toml